### PR TITLE
Humanize navigation and form identifiers

### DIFF
--- a/Proyecto WEB/web/agenda.html
+++ b/Proyecto WEB/web/agenda.html
@@ -13,21 +13,18 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>
         <a class="nav-link" href="barberos.html">Barberos</a>
         <a class="nav-link" href="galeria.html">Galería</a>
         <a class="nav-link" href="contacto.html">Contacto</a>
-       <a class="nav-link" href="#" id="botonLogout">Logout</a>
-      </nav>
-
-
+        <a class="nav-link" href="#" id="boton-cerrar-sesion">Cerrar sesión</a>
       </nav>
     </div>
   </header>

--- a/Proyecto WEB/web/barberos.html
+++ b/Proyecto WEB/web/barberos.html
@@ -16,11 +16,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>

--- a/Proyecto WEB/web/contacto.html
+++ b/Proyecto WEB/web/contacto.html
@@ -15,11 +15,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>

--- a/Proyecto WEB/web/css/style.css
+++ b/Proyecto WEB/web/css/style.css
@@ -54,7 +54,7 @@ body {
 }
 
 /* Botón hamburger */
-.navbar-toggle {
+.boton-menu {
   background: none;
   border: none;
   color: white;
@@ -71,16 +71,16 @@ body {
   justify-content: center;
 }
 
-.navbar-toggle:hover {
+.boton-menu:hover {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-.navbar-toggle:focus {
+.boton-menu:focus {
   outline: 2px solid rgba(255, 255, 255, 0.5);
   outline-offset: 2px;
 }
 
-.navbar-menu {
+.menu-navegacion {
   display: flex;
   align-items: center;
 }
@@ -153,11 +153,11 @@ body {
     height: 40px;
   }
 
-  .navbar-toggle {
+  .boton-menu {
     display: flex !important;
   }
 
-  .navbar-menu {
+  .menu-navegacion {
     position: absolute;
     top: 100%;
     left: 0;
@@ -171,7 +171,7 @@ body {
     display: none;
   }
 
-  .navbar-menu.active {
+  .menu-navegacion.active {
     display: flex;
   }
 
@@ -237,7 +237,7 @@ body {
 
 /* Media query para dispositivos muy pequeños */
 @media (max-width: 480px) {
-  .navbar-toggle {
+  .boton-menu {
     display: flex !important;
   }
 

--- a/Proyecto WEB/web/galeria.html
+++ b/Proyecto WEB/web/galeria.html
@@ -15,11 +15,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>

--- a/Proyecto WEB/web/index.html
+++ b/Proyecto WEB/web/index.html
@@ -15,11 +15,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>

--- a/Proyecto WEB/web/js/script.js
+++ b/Proyecto WEB/web/js/script.js
@@ -25,7 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   let listaDeReservas = JSON.parse(localStorage.getItem("misReservas")) || [];
 
-  let formularioDeReserva = document.getElementById("form");
+  let formularioDeReserva = document.getElementById("formulario-reserva");
   if (formularioDeReserva) {
     formularioDeReserva.addEventListener("submit", function (evento) {
       evento.preventDefault();
@@ -117,7 +117,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  let formularioDeLogin = document.getElementById("formLogin");
+  let formularioDeLogin = document.getElementById("formulario-login");
   if (formularioDeLogin && document.getElementById("usuario")) {
     formularioDeLogin.addEventListener("submit", iniciarSesion);
   }
@@ -159,9 +159,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 });
 
-let botonLogout = document.getElementById("botonLogout");
-if (botonLogout) {
-  botonLogout.addEventListener("click", function (evento) {
+let botonCerrarSesion = document.getElementById("boton-cerrar-sesion");
+if (botonCerrarSesion) {
+  botonCerrarSesion.addEventListener("click", function (evento) {
     evento.preventDefault();
     sessionStorage.removeItem("usuarioLogueado");
     window.location.href = "login.html";
@@ -171,47 +171,47 @@ if (botonLogout) {
 // Funcionalidad del menú hamburger - Versión simplificada y funcional
 document.addEventListener('DOMContentLoaded', function() {
   console.log('Script cargado - Iniciando menú hamburger');
-  
-  const navbarToggle = document.getElementById('navbar-toggle');
-  const navbarMenu = document.getElementById('navbar-menu');
 
-  console.log('Toggle button:', navbarToggle);
-  console.log('Menu:', navbarMenu);
+  const botonMenu = document.getElementById('boton-menu');
+  const menuNavegacion = document.getElementById('menu-navegacion');
 
-  if (navbarToggle && navbarMenu) {
+  console.log('Botón de menú:', botonMenu);
+  console.log('Menú de navegación:', menuNavegacion);
+
+  if (botonMenu && menuNavegacion) {
     console.log('Elementos encontrados, configurando eventos');
-    
+
     // Toggle del menú al hacer clic en el botón hamburger
-    navbarToggle.addEventListener('click', function(e) {
+    botonMenu.addEventListener('click', function(e) {
       e.preventDefault();
       e.stopPropagation();
-      console.log('Click en hamburger');
-      navbarMenu.classList.toggle('active');
-      console.log('Menu active:', navbarMenu.classList.contains('active'));
+      console.log('Click en botón de menú');
+      menuNavegacion.classList.toggle('active');
+      console.log('Menú activo:', menuNavegacion.classList.contains('active'));
     });
 
     // Cerrar el menú cuando se hace clic en un enlace
-    const navLinks = navbarMenu.querySelectorAll('.nav-link');
+    const navLinks = menuNavegacion.querySelectorAll('.nav-link');
     navLinks.forEach(link => {
       link.addEventListener('click', function() {
         console.log('Click en enlace, cerrando menú');
-        navbarMenu.classList.remove('active');
+        menuNavegacion.classList.remove('active');
       });
     });
 
     // Cerrar el menú cuando se hace clic fuera de él
     document.addEventListener('click', function(event) {
-      const isClickInsideNav = navbarToggle.contains(event.target) || navbarMenu.contains(event.target);
-      if (!isClickInsideNav && navbarMenu.classList.contains('active')) {
+      const clickDentroDelMenu = botonMenu.contains(event.target) || menuNavegacion.contains(event.target);
+      if (!clickDentroDelMenu && menuNavegacion.classList.contains('active')) {
         console.log('Click fuera del menú, cerrando');
-        navbarMenu.classList.remove('active');
+        menuNavegacion.classList.remove('active');
       }
     });
 
     // Cerrar el menú al cambiar el tamaño de la ventana (si se hace más grande)
     window.addEventListener('resize', function() {
       if (window.innerWidth > 768) {
-        navbarMenu.classList.remove('active');
+        menuNavegacion.classList.remove('active');
       }
     });
   } else {

--- a/Proyecto WEB/web/login.html
+++ b/Proyecto WEB/web/login.html
@@ -15,11 +15,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>
@@ -35,7 +35,7 @@
   <main class="hero content-page">
     <section class="login-form text-white text-center">
       <h2 class="mb-4">Iniciar sesión</h2>
-      <form id="formLogin">
+      <form id="formulario-login">
   <div class="mb-3 text-start">
     <label for="usuario" class="form-label">Usuario:</label>
     <input type="text" class="form-control" id="usuario" required />

--- a/Proyecto WEB/web/precios.html
+++ b/Proyecto WEB/web/precios.html
@@ -16,11 +16,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
       
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
       
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>

--- a/Proyecto WEB/web/reservas.html
+++ b/Proyecto WEB/web/reservas.html
@@ -17,11 +17,11 @@
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="img/logo.png" alt="Logo Estilo Clásico" class="logo" />
 
-      <button class="navbar-toggle" id="navbar-toggle">
+      <button class="boton-menu" id="boton-menu">
         ☰
       </button>
 
-      <nav class="navbar-menu" id="navbar-menu">
+      <nav class="menu-navegacion" id="menu-navegacion">
         <a class="nav-link" href="index.html">Inicio</a>
         <a class="nav-link" href="reservas.html">Reservar Turno</a>
         <a class="nav-link" href="precios.html">Precios</a>
@@ -37,7 +37,7 @@
     <section class="reserva-form">
       <div id="confirmation" class="hidden mt-3"></div>
       <h2>Reserva tu turno</h2>
-      <form id="form">
+      <form id="formulario-reserva">
         <div class="row">
           <div class="col-md-6 mb-3">
             <label for="nombre" class="form-label">Nombre:</label>


### PR DESCRIPTION
## Summary
- Replace `navbar-toggle`/`navbar-menu` with Spanish-friendly `boton-menu` and `menu-navegacion`
- Rename logout and form IDs for clearer semantics across pages

## Testing
- `npm test` *(fails: Module ... in the testRunner option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a680668d883229cbe7e7f77101b16